### PR TITLE
Refactor codebase

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -37,7 +37,7 @@ fn discord_token_default() -> String {
     String::from("Please provide a token")
 }
 
-#[derive(Debug, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, PartialOrd, Serialize, Deserialize, Clone)]
 pub struct Config {
     #[serde(rename = "discordToken", default = "discord_token_default")]
     pub discord_token: String,
@@ -88,7 +88,7 @@ impl ConfigHandler {
 
     pub fn create_config_dir_path(&self) -> Result<(), ConfigInitError> {
         let path = self.get_config_dir_path()?;
-        std::fs::create_dir_all(path)?;
+        fs::create_dir_all(path)?;
         Ok(())
     }
 
@@ -112,7 +112,7 @@ impl ConfigHandler {
         Ok(())
     }
 
-    pub fn get_config(&self) -> Result<Config, ConfigParseError> {
+    pub fn load_config(&self) -> Result<Config, ConfigParseError> {
         let path = self.get_config_file_path()?;
         if !path.exists() {
             self.create_config_dir_path()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,5 @@
 use ::log::{error, warn};
-use lum::{
-    bot::Bot,
-    config::{Config, ConfigHandler, ConfigParseError},
-    log,
-    service::Service,
-};
+use lum::{bot::Bot, config::ConfigHandler, log, service::Service};
 
 const BOT_NAME: &str = "Lum";
 
@@ -16,7 +11,8 @@ async fn main() {
         warn!("THIS IS A DEBUG RELEASE!");
     }
 
-    let _config = match get_config() {
+    let config_handler = ConfigHandler::new(BOT_NAME.to_lowercase().as_str());
+    let _config = match config_handler.load_config() {
         Ok(config) => config,
         Err(err) => {
             error!(
@@ -42,11 +38,6 @@ fn setup_logger() {
             error, BOT_NAME
         );
     }
-}
-
-fn get_config() -> Result<Config, ConfigParseError> {
-    let config_handler = ConfigHandler::new(BOT_NAME.to_lowercase().as_str());
-    config_handler.get_config()
 }
 
 fn initialize_services() -> Vec<Box<dyn Service>> {


### PR DESCRIPTION
 - Refined some derived traits
 - Refactor Service/ServiceInfo: Move some trait implementations from Service to ServiceInfo and refer to the implementations from Service
 - Compare ID instead of name in ServiceManagerBuilder