### PR TITLE
Fix service framework

### DIFF
--- a/src/bot.rs
+++ b/src/bot.rs
@@ -41,7 +41,7 @@ impl BotBuilder {
 
 pub struct Bot {
     pub name: String,
-    pub service_manager: Arc<RwLock<ServiceManager>>,
+    pub service_manager: Arc<ServiceManager>,
 }
 
 impl Bot {
@@ -52,7 +52,7 @@ impl Bot {
     //TODO: When Rust allows async trait methods to be object-safe, refactor this to use async instead of returning a future
     pub fn start(&mut self) -> PinnedBoxedFuture<'_, ()> {
         Box::pin(async move {
-            self.service_manager.write().await.start_services().await;
+            self.service_manager.start_services().await;
             //TODO: Potential for further initialization here, like modules
         })
     }
@@ -60,7 +60,7 @@ impl Bot {
     //TODO: When Rust allows async trait methods to be object-safe, refactor this to use async instead of returning a future
     pub fn stop(&mut self) -> PinnedBoxedFuture<'_, ()> {
         Box::pin(async move {
-            self.service_manager.write().await.stop_services().await;
+            self.service_manager.stop_services().await;
             //TODO: Potential for further deinitialization here, like modules
         })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,9 +36,8 @@ pub async fn run(mut bot: Bot) {
         }
     };
 
-    let service_manager = bot.service_manager.read().await;
-    if service_manager.overall_status().await != OverallStatus::Healthy {
-        let status_tree = service_manager.status_tree().await;
+    if bot.service_manager.overall_status().await != OverallStatus::Healthy {
+        let status_tree = bot.service_manager.status_tree().await;
 
         error!("{} is not healthy! Some essential services did not start up successfully. Please check the logs.\nService status tree:\n{}\n{} will exit.",
         bot.name,
@@ -46,7 +45,6 @@ pub async fn run(mut bot: Bot) {
         bot.name);
         return;
     }
-    drop(service_manager);
 
     info!("{} is alive", bot.name,);
 

--- a/src/service/discord.rs
+++ b/src/service/discord.rs
@@ -14,6 +14,7 @@ use serenity::{
 };
 use std::{sync::Arc, time::Duration};
 use tokio::{
+    spawn,
     sync::{Mutex, Notify, RwLock},
     task::JoinHandle,
     time::{sleep, timeout},
@@ -56,10 +57,7 @@ impl Service for DiscordService {
         &self.info
     }
 
-    fn start(
-        &mut self,
-        _service_manager: Arc<RwLock<ServiceManager>>,
-    ) -> PinnedBoxedFutureResult<'_, ()> {
+    fn start(&mut self, _service_manager: Arc<ServiceManager>) -> PinnedBoxedFutureResult<'_, ()> {
         Box::pin(async move {
             let framework = StandardFramework::new();
             framework.configure(Configuration::new().prefix("!"));
@@ -101,7 +99,7 @@ impl Service for DiscordService {
             }
 
             info!("Connecting to Discord");
-            let client_handle = tokio::spawn(async move { client.start().await });
+            let client_handle = spawn(async move { client.start().await });
 
             // This prevents waiting for the timeout if the client fails immediately
             // TODO: Optimize this, as it will currently add 1000mqs to the startup time


### PR DESCRIPTION
 - Fix deadlock when accessing the ServiceManager parameter in start() method of a Service
 - Known bug: Deadlock still happens when a service accesses itself through the ServiceManager on start