### PR TITLE
Merge refactor/async into staging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1182,6 +1182,7 @@ dependencies = [
 name = "lum"
 version = "0.2.1"
 dependencies = [
+ "async-trait",
  "dirs",
  "downcast-rs",
  "fern",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/Kitt3120/lum"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+async-trait = "0.1.83"
 dirs = "5.0.1"
 downcast-rs = "1.2.0"
 fern = { version = "0.6.2", features = ["chrono", "colored", "date-based"] }

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -4,9 +4,7 @@ use std::{fmt::Display, sync::Arc};
 use log::error;
 use tokio::{signal, sync::Mutex};
 
-use crate::service::{
-    types::LifetimedPinnedBoxedFuture, OverallStatus, Service, ServiceManager, ServiceManagerBuilder,
-};
+use crate::service::{OverallStatus, Service, ServiceManager, ServiceManagerBuilder};
 
 #[derive(Debug, Clone, Copy)]
 pub enum ExitReason {
@@ -68,20 +66,14 @@ impl Bot {
         BotBuilder::new(name)
     }
 
-    //TODO: When Rust allows async trait methods to be object-safe, refactor this to use async instead of returning a future
-    pub fn start(&mut self) -> LifetimedPinnedBoxedFuture<'_, ()> {
-        Box::pin(async move {
-            self.service_manager.start_services().await;
-            //TODO: Potential for further initialization here, like modules
-        })
+    pub async fn start(&mut self) {
+        self.service_manager.start_services().await;
+        //TODO: Potential for further initialization here, like modules
     }
 
-    //TODO: When Rust allows async trait methods to be object-safe, refactor this to use async instead of returning a future
-    pub fn stop(&mut self) -> LifetimedPinnedBoxedFuture<'_, ()> {
-        Box::pin(async move {
-            self.service_manager.stop_services().await;
-            //TODO: Potential for further deinitialization here, like modules
-        })
+    pub async fn stop(&mut self) {
+        self.service_manager.stop_services().await;
+        //TODO: Potential for further deinitialization here, like modules
     }
 
     pub async fn join(&self) -> ExitReason {

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,6 +1,4 @@
 pub mod discord;
-// TODO: Used for downcast_rs. Maybe this can be removed when updating the crate.
-#[allow(clippy::multiple_bound_locations)]
 pub mod service; // Will be fixed when lum gets seperated into multiple workspaces
 pub mod service_manager;
 pub mod types;
@@ -9,7 +7,7 @@ pub mod watchdog;
 pub use service::{Service, ServiceInfo};
 pub use service_manager::{ServiceManager, ServiceManagerBuilder};
 pub use types::{
-    BoxedError, BoxedFuture, BoxedFutureResult, OverallStatus, PinnedBoxedFuture, PinnedBoxedFutureResult,
-    Priority, ShutdownError, StartupError, Status,
+    BoxedError, LifetimedPinnedBoxedFuture, LifetimedPinnedBoxedFutureResult, OverallStatus,
+    PinnedBoxedFuture, PinnedBoxedFutureResult, Priority, ShutdownError, StartupError, Status,
 };
 pub use watchdog::Watchdog;

--- a/src/service/types.rs
+++ b/src/service/types.rs
@@ -1,4 +1,9 @@
-use std::{error::Error, fmt::Display, future::Future, pin::Pin};
+use std::{
+    error::Error,
+    fmt::{self, Display},
+    future::Future,
+    pin::Pin,
+};
 
 use thiserror::Error;
 
@@ -6,13 +11,10 @@ use crate::event::event_repeater::{AttachError, DetachError};
 
 pub type BoxedError = Box<dyn Error + Send + Sync>;
 
-pub type BoxedFuture<T> = Box<dyn Future<Output = T> + Send>;
-pub type BoxedFutureResult<T> = BoxedFuture<Result<T, BoxedError>>;
-
-pub type PinnedBoxedFuture<T> = Pin<Box<dyn Future<Output = T> + Send>>;
+pub type PinnedBoxedFuture<T> = Pin<Box<dyn Future<Output = T> + Send + Sync>>;
 pub type PinnedBoxedFutureResult<T> = PinnedBoxedFuture<Result<T, BoxedError>>;
 
-pub type LifetimedPinnedBoxedFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+pub type LifetimedPinnedBoxedFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + Sync + 'a>>;
 pub type LifetimedPinnedBoxedFutureResult<'a, T> = LifetimedPinnedBoxedFuture<'a, Result<T, BoxedError>>;
 
 #[derive(Debug, Clone)]
@@ -27,7 +29,7 @@ pub enum Status {
 }
 
 impl Display for Status {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Status::Started => write!(f, "Started"),
             Status::Stopped => write!(f, "Stopped"),
@@ -64,7 +66,7 @@ pub enum OverallStatus {
 }
 
 impl Display for OverallStatus {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             OverallStatus::Healthy => write!(f, "Healthy"),
             OverallStatus::Unhealthy => write!(f, "Unhealthy"),
@@ -79,7 +81,7 @@ pub enum Priority {
 }
 
 impl Display for Priority {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Priority::Essential => write!(f, "Essential"),
             Priority::Optional => write!(f, "Optional"),

--- a/src/service/watchdog.rs
+++ b/src/service/watchdog.rs
@@ -1,4 +1,3 @@
-use super::types::LifetimedPinnedBoxedFuture;
 use log::error;
 use serenity::FutureExt;
 use std::{future::Future, mem::replace, sync::Arc};
@@ -6,6 +5,8 @@ use tokio::sync::{
     mpsc::{channel, Receiver, Sender},
     Mutex,
 };
+
+use super::LifetimedPinnedBoxedFuture;
 
 //TODO: Rename to TaskChain and use Event<T> instead of manual subscriber handling
 pub struct Watchdog<'a, T: Send> {
@@ -23,8 +24,8 @@ impl<'a, T: 'a + Send> Watchdog<'a, T> {
 
     pub fn append<FN, FUT>(&mut self, task: FN)
     where
-        FN: FnOnce(T) -> FUT + Send + 'a,
-        FUT: Future<Output = T> + Send + 'a,
+        FN: FnOnce(T) -> FUT + Send + Sync + 'a,
+        FUT: Future<Output = T> + Send + Sync + 'a,
     {
         let previous_task = replace(
             &mut self.task,


### PR DESCRIPTION
This adds the async_trait crate to the project and uses it where possible, eliminating a lot of `Box::pin(async move { ... })` statements.