### PR TITLE
docs: update license copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Torben Schweren
+Copyright (c) 2023-2024 Torben Schweren, Marco Murawski
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This pull request includes a small change to the `LICENSE` file. The change updates the copyright information to include an additional year and a new contributor.

* [`LICENSE`](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7L3-R3): Updated the copyright year to 2023-2024 and added Marco Murawski as a contributor.