### PR TITLE
Add support for nix-shell

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "nixEnvSelector.nixFile": "${workspaceFolder}/shell.nix"
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,30 @@
+{
+  pkgs ? import <nixpkgs> { },
+}:
+
+pkgs.mkShell {
+  buildInputs = [
+    pkgs.rustup
+  ];
+
+  shellHook = ''
+    DATA_DIR=/tmp/rust/lum
+    export RUSTUP_HOME=$DATA_DIR/rustup
+    export CARGO_HOME=$DATA_DIR/cargo
+    export PATH=$CARGO_HOME/bin:$PATH
+    mkdir -p $CARGO_HOME
+    mkdir -p $RUSTUP_HOME
+
+    rustup default stable
+    rustup update
+    cargo fetch
+
+    echo
+    echo
+    echo
+
+    echo "Rustup installed at $RUSTUP_HOME"
+    echo "Cargo installed at $CARGO_HOME"
+    echo $(cargo --version)
+  '';
+}


### PR DESCRIPTION
This pull request includes changes to set up the development environment using nix-shell. The most important changes include adding a nix-shell configuration, specifying the Rust toolchain, and updating VS Code settings.

Environment setup:

* [`shell.nix`](diffhunk://#diff-e53dfbfffe62ae3c0b411b3938ccffa9fb6a2ecc565f55785ef8daa756631a6bR1-R30): Added a nix-shell configuration to set up the Rust development environment, including installing `rustup`, configuring environment variables, and ensuring the `stable` Rust toolchain is used.
* [`rust-toolchain.toml`](diffhunk://#diff-2b1bde2cf3a858b7bf7424cb8bcbf01f35b94dc80b925d9432cbab3319ca9b4eR1-R2): Specified the Rust toolchain to use the `stable` channel.

Editor configuration:

* [`.vscode/settings.json`](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357R1-R3): Updated VS Code settings to use `shell.nix` as the environment on startup, should Nix Environment Selector be installed.